### PR TITLE
Allow subscripting of 'forms' variable in template.

### DIFF
--- a/shapeshifter/views.py
+++ b/shapeshifter/views.py
@@ -18,7 +18,7 @@ class MultiFormView(TemplateView):
     def get_context_data(self, **kwargs):
         if "forms" not in kwargs:
             forms = self.get_forms()
-            kwargs["forms"] = forms.values()
+            kwargs["forms"] = list(forms.values())
             kwargs.update(**forms)
         return super(MultiFormView, self).get_context_data(**kwargs)
 


### PR DESCRIPTION
`forms.values()` returns a `dict_keys` objects in Python 3, which is not subscriptable. Casting `forms.values()` to a list allows subscripting in the template (`forms.0`, `forms.1` etc.).